### PR TITLE
Error dialog improvements

### DIFF
--- a/v2/app.js
+++ b/v2/app.js
@@ -220,6 +220,10 @@ export class App{
                 }else{
                     this.notificationsDevice = device;
                 }
+                if(!device){
+                    await alert("You don't have a device that you can view files on.");
+                    return;
+                }
                 return {app:this,device};
             },
             icon:`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M16 0H8C6.9 0 6 .9 6 2V18C6 19.1 6.9 20 8 20H20C21.1 20 22 19.1 22 18V6L16 0M20 18H8V2H15V7H20V18M4 4V22H20V24H4C2.9 24 2 23.1 2 22V4H4Z"/></svg>`


### PR DESCRIPTION
Added an error dialog when the user clicks on the file browser and does not have a device with the ability to view files on it (like a phone). Similar to the way a user can't access the notification view if they don't have a device capable of notifications